### PR TITLE
Customize USB identification for mouse

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -1,0 +1,6 @@
+import supervisor
+import usb_hid
+
+supervisor.set_usb_identification(product="USB Mouse", manufacturer="Goldenboy Industries")
+
+usb_hid.enable((usb_hid.Device.MOUSE,), boot_device=1)


### PR DESCRIPTION
## Summary
- update the USB manufacturer string so the device enumerates as "Goldenboy Industries"

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d478008874833396fba77c1d69b0e9